### PR TITLE
Added option to change the show tab behaviour

### DIFF
--- a/jquery.stickytabs.js
+++ b/jquery.stickytabs.js
@@ -11,6 +11,7 @@
         var settings = $.extend({
             getHashCallback: function(hash, btn) { return hash },
             selectorAttribute: "href",
+            showTabUsingClickTrigger: false,
             backToTop: false,
             initialTab: $('li.active > a', context)
         }, options );
@@ -20,7 +21,11 @@
           var hash = settings.selectorAttribute == "href" ? window.location.hash : window.location.hash.substring(1);
           if (hash != '') {
               var selector = hash ? 'a[' + settings.selectorAttribute +'="' + hash + '"]' : settings.initialTab;
-              $(selector, context).tab('show');
+              if (settings.showTabUsingClickTrigger === true) {
+                $(selector, context).trigger('click');
+              } else {
+                $(selector, context).tab('show');
+              }
               setTimeout(backToTop, 1);
           }
         }


### PR DESCRIPTION
Issue - showing the tab doesn't trigger any applied behaviours.

Based on a new option as to not change current behaviour, this change changes from using a tab('show') to a trigger('click') which would then set off any behaviours that have been set against the click.